### PR TITLE
tracked.hh: Add <unordered_map> include

### DIFF
--- a/tracked.hh
+++ b/tracked.hh
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <math.h>
 #include <unordered_set>
+#include <unordered_map>
 #include "fvector.hh"
 #include "trackedfuncs.hh"
 extern std::ofstream g_tree;


### PR DESCRIPTION
On some Linux systems, an include of <unordered_map> is needed in tracked.hh in order to build properly.